### PR TITLE
docs: update README with new local server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Ensure you have the following installed on your machine:
 
 3. **Access the Application**
 
-   Open your browser and navigate to `http://localhost:3000` to see the application in action.
+   Open your browser and navigate to `http://localhost:5173` to see the application in action.
 
 ## Scripts
 

--- a/client/index.html
+++ b/client/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite + React + Flask</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>


### PR DESCRIPTION
- Updated the local server URL in README.md to `http://localhost:5173` for accurate instructions.
- Updated title in `index.html` to reflect Vite + React + Flask stack.

This change provides clarity for users by ensuring the documentation and application structure accurately represent the current setup.